### PR TITLE
Add support for TECNO POVA 4 non-Pro(LG7n)

### DIFF
--- a/injector/devices.py
+++ b/injector/devices.py
@@ -258,5 +258,54 @@ DEVICES = [
             )
         },
         base=0xFFFF000050F00000
+    ),
+    Device(
+        'LG7n',
+        'Tecno Pova 4',
+        {
+            'sec_get_vfy_policy': PatchStage(
+                'sec_get_vfy_policy',
+                pattern='00 01 00 b4 fd 7b bf a9',
+                replacement='00 00 80 52 c0 03 5f d6',
+                match_mode=MatchMode.ALL,
+                description='Don\'t enforce secure boot policy',
+            ),
+            'force_green_state': PatchStage(
+                'force_green_state',
+                pattern='c8 02 00 f0 00 29 0a b9 c0 03 5f d6',
+                replacement='c8 02 00 f0 1f 29 0a b9 c0 03 5f d6',
+                match_mode=MatchMode.ALL,
+                description='Force boot state to always be set to green',
+            ),
+            'bypass_security_control': PatchStage(
+                'bypass_security_control',
+                pattern='e8 0b 40 b9 1f 0d 00 71 21 01 00 54',
+                replacement='e8 0b 40 b9 1f 0d 00 71 1f 20 03 d5',
+                match_mode=MatchMode.ALL,
+                description='Skip security check - always execute commands',
+            ),
+            'spoof_sboot_state': PatchStage(
+                'spoof_get_sboot_state',
+                pattern='fd 7b be a9 f3 0b 00 f9 fd 03 00 91 f3 03 00 aa 20 00 80 52 c9',
+                replacement='48 04 80 52 08 00 00 b9 00 00 80 52 c0 03 5f d6 1f 20 03 d5 c9',
+                match_mode=MatchMode.ALL,
+                description='Force sboot state to always be ATTR_SBOOT_ONLY_ENABLE_ON_SCHIP',
+            ),
+            'spoof_lock_state': PatchStage(
+                'spoof_lock_state',
+                pattern='20 02 00 b4 fd 7b be a9 f3 0b 00 f9 fd 03 00 91',
+                replacement='88 00 80 52 08 00 00 b9 00 00 80 52 c0 03 5f d6',
+                match_mode=MatchMode.ALL,
+                description='Force lock state to always be LKS_LOCK',
+            ),
+            'dont_relock_seccfg': PatchStage(
+                'dont_relock_seccfg',
+                pattern='fd 7b be a9 f3 0b 00 f9 fd 03 00 91 f3 03 00 2a 28 00 80 52',
+                replacement='00 00 80 52 c0 03 5f d6 1f 20 03 d5 1f 20 03 d5 1f 20 03 d5',
+                match_mode=MatchMode.ALL,
+                description='Prevent LK from relocking seccfg',
+            ),
+        },
+        base=0xFFFF000050F00000
     )
 ]


### PR DESCRIPTION
Based on the LG8n implementation, changed the address for force_green_state to the one used by LG7n