### PR TITLE
fenrir: Add complete Tetris (CMF Phone 1) support

### DIFF
--- a/injector/devices.py
+++ b/injector/devices.py
@@ -499,4 +499,22 @@ DEVICES = [
         },
         base=0xFFFF000050700000
     ),
+    Device(
+        'Tetris',
+        'CMF Phone 1 by Nothing',
+        {
+            # Verified on build 2408282341, Android 14 (SDK 34)
+            # lk_a SHA256: 7bd0be99905183ab86db04a5afe2aed36efc66c5aa60b8bf87ba80555908224b
+            # Only sec_get_vfy_policy patched — 3 sites in bl2_ext, 3 bytes changed total.
+            # No additional patches added — unverified on this device.
+            'sec_get_vfy_policy': PatchStage(
+                'sec_get_vfy_policy',
+                pattern='20 00 80 52 c0 03 5f d6',
+                replacement='00 00 80 52 c0 03 5f d6',
+                match_mode=MatchMode.ALL,
+                description='Don\'t enforce secure boot policy',
+            ),
+        },
+        base=0xFFFF000050700000,
+    ),
 ]


### PR DESCRIPTION
Adds complete support for CMF Phone 1 (Tetris, MT6878, Android 14).

Tested on build 2408282341.
lk_a SHA256: 7bd0be99905183ab86db04a5afe2aed36efc66c5aa60b8bf87ba80555908224b

Only sec_get_vfy_policy is patched — 3 sites in bl2_ext, 3 bytes changed.
base confirmed from expdb: 0xFFFF000050700000

No additional patches (lock state, sboot, green state) are included.
Those have not been verified on this device and could brick it.

Notes:
- Flashing without formatting the f2fs partition will boot directly 
  into recovery. Format data before flashing.
- If you ever get to recovery, DON'T CLICK Restore and DON'T panic (Read the recovery  
 section below)
- Only tested on the exact build and SHA256 above. Different builds 
  may have different offsets.
- I AM NOT RESPONSIBLE FOR BRICKED DEVICES.

Recovery Mode Notice (Read before flashing)
If you boot into recovery after flashing, don't panic — you simply forgot to wipe user data (wipe data because f2fs needs to wiped first!).
Do NOT tap "Factory reset" from the recovery menu — this may trigger FRP (Factory Reset Protection) lock
Do NOT run fastboot reboot bootloader — this loops you back to the same recovery screen
Instead, run adb reboot fastboot — this takes you into fastbootd (ensure you have a device your phone trusted for usb debugging before anything happens)
Once in fastbootd, select the reboot to Bootloader tab and wipe the following partitions:
userdata (required)
misc (recommended)
metadata (recommended)
Leave the fenrir-patched lk_a intact — do not reflash stock
Then run fastboot reboot — device boots normally
---
> *With love <3 — El-HOOT*